### PR TITLE
Pass peer name to socket implementation.

### DIFF
--- a/lib/LWPx/Protocol/http_paranoid.pm
+++ b/lib/LWPx/Protocol/http_paranoid.pm
@@ -65,6 +65,7 @@ sub _new_socket
             (time() - $request->{_timebegin}) :
             $timeout;
         $sock = $self->socket_class->new(PeerAddr => $addr,
+                                         PeerHost => $host,
                                          PeerPort => $port,
                                          Proto    => 'tcp',
                                          Timeout  => $conn_timeout,


### PR DESCRIPTION
This way, IO::Socket::SSL gets a chance to verify the hostname.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=738493 for
details.
