### PR TITLE
Proper fix for issue #4

### DIFF
--- a/lib/LWPx/Protocol/http_paranoid.pm
+++ b/lib/LWPx/Protocol/http_paranoid.pm
@@ -10,6 +10,8 @@ require HTTP::Response;
 require HTTP::Status;
 require Net::HTTP;
 
+use Errno qw(EAGAIN);
+
 use vars qw(@ISA $TOO_LATE $TIME_REMAIN);
 
 require LWP::Protocol;
@@ -363,8 +365,9 @@ sub request
 	{
         _set_time_remain();
 	    $n = $socket->read_entity_body($buf, $size);
-	    die "Can't read entity body: $!" unless defined $n;
 	    redo READ if $n == -1;
+	    redo READ if not defined $n and $! == EAGAIN;
+	    die "Can't read entity body: $!" unless defined $n;
 	    die 'read timeout' unless($TIME_REMAIN - 1);
 	}
 	$complete++ if !$n;


### PR DESCRIPTION
It turns out that Net::HTTP::read_entity_body's documentation is not
100% accurate: When used with IO::Socket::SSL, it may return undef
and set $! to EAGAIN if "no data could be returned this time".
(This is pretty much what one would expect from a UNIX-like API, anyway.)
