### PR TITLE
Gracefully handle Net::DNS 1.03 API changes.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,37 +1,43 @@
+1.12	2015-11-18
+	- Fix to work with Net::DNS 1.03 (RT#108745)
+	  Net::DNS::bgsend()/bgread() API changed in a backward-incompatible
+	  way in 1.03. Deal with either a IO::Select object or a socket, as it
+	  was before.  (Cosimo Streppone <cosimo@cpan.org>)
+
 1.11	2014-
 	- fixed read-timeout issue: https://github.com/csirtgadgets/LWPx-ParanoidAgent/issues/7
 
 1.10	2013-11-11
 	- fixed: https://github.com/csirtgadgets/LWPx-ParanoidAgent/issues/3
-    - fixed: https://github.com/csirtgadgets/LWPx-ParanoidAgent/issues/4
+	- fixed: https://github.com/csirtgadgets/LWPx-ParanoidAgent/issues/4
 
-1.09:       2013-05-02
-    - released
-    - Makefile.PL updated
+1.09:   2013-05-02
+	- released
+	- Makefile.PL updated
 
 1.08_02:    2013-04-29
-    - removed TLS test for now, some cpan testers reporting issues with the configuration, seems pointless given the Makefile
+	- removed TLS test for now, some cpan testers reporting issues with the configuration, seems pointless given the Makefile
 
 1.08_01:    2013-04-26
-    - removed some of the tests that seem to fail on congested machines (eg: cpantesters).
+	- removed some of the tests that seem to fail on congested machines (eg: cpantesters).
 
 1.08:       2013-03-30
-    - [SREZIC] added mirror support: https://rt.cpan.org/Ticket/Display.html?id=44569
+	- [SREZIC] added mirror support: https://rt.cpan.org/Ticket/Display.html?id=44569
 
 1.07:  2009-08-05
 	- Skip the whole test when it can't bind to the specified private IP
 	  (Tatsuhiko Miyagawa)
 	- Fix the way to get LWP error when it's set to X-Died instead of $@
 	  (Zbigniew Lukasiak)
-	
+
 1.06:  2009-07-17
 	- explicitly load deprecated module LWP::Debug, now that it's not
 	  loaded by default.  (Tatsuhiko Miyagawa <miyagawa@gmail.com>)
 
 1.05:  2009-06-21
-        - patch from Alessio Signorini <alessio.signorini@spryte.it> to
+	- patch from Alessio Signorini <alessio.signorini@spryte.it> to
 	  quiet a warning that could be triggered
-	
+
 1.04:  2008-10-30
 	- fix tests to no longer rely on my DNS servers, which had since migrated
 	  to EasyDNS which doesn't allow the types of malicious records I was
@@ -63,4 +69,4 @@
 	  rather than using an xinetd script
 
 0.99:  2005-05-19
-     - initial release
+	- initial release


### PR DESCRIPTION
Net::DNS::bgsend()/bgread() API changed in Net::DNS 1.03,
and it's unfortunately backward incompatible. More details in RT#108745 (https://rt.cpan.org/Ticket/Display.html?id=108745). This patch allows LWPx::ParanoidAgent to gracefully work with Net::DNS 1.03 as well.

My vested interest in this is that my downstream Net::Prober broke instantly when people upgraded to Net::DNS 1.03 by way of LWPx::ParanoidAgent :-)

https://rt.cpan.org/Ticket/Display.html?id=109092
