### PR TITLE
Connection is stuck if remote host didn't send any header in return

### DIFF
--- a/lib/LWPx/Protocol/http_paranoid.pm
+++ b/lib/LWPx/Protocol/http_paranoid.pm
@@ -335,13 +335,7 @@ sub request
     ## Check host started to send any data in return
     my $rbits = '';
     vec($rbits, fileno($socket), 1) = 1;
-    my $headers_wait_for = $TIME_REMAIN;
-    my $nfound = undef;
-    while (1) {
-        $nfound = select($rbits, undef, undef, $headers_wait_for--);
-        last if $nfound;
-        last if $headers_wait_for < 0;
-    }
+    my $nfound = select($rbits, undef, undef, $TIME_REMAIN);
     die "Headers not came for $TIME_REMAIN sec" unless $nfound;
 
     _set_time_remain();
@@ -436,6 +430,8 @@ sub sysread {
 
 sub can_read {
     my($self, $timeout) = @_;
+
+    $timeout ||= $LWPx::Protocol::http_paranoid::TIME_REMAIN;
     my $fbits = '';
     vec($fbits, fileno($self), 1) = 1;
     my $nfound = select($fbits, undef, undef, $timeout);

--- a/lib/LWPx/Protocol/http_paranoid.pm
+++ b/lib/LWPx/Protocol/http_paranoid.pm
@@ -330,6 +330,22 @@ sub request
     }
 
     _set_time_remain();
+
+    ## Now we connected to host
+    ## Check host started to send any data in return
+    my $rbits = '';
+    vec($rbits, fileno($socket), 1) = 1;
+    my $headers_wait_for = $TIME_REMAIN;
+    my $nfound = undef;
+    while (1) {
+        $nfound = select($rbits, undef, undef, $headers_wait_for--);
+        last if $nfound;
+        last if $headers_wait_for < 0;
+    }
+    die "Headers not came for $TIME_REMAIN sec" unless $nfound;
+
+    _set_time_remain();
+
     ($code, $mess, @h) = $socket->read_response_headers(laxed => 1, junk_out => \@junk)
 	unless $code;
     ($code, $mess, @h) = $socket->read_response_headers(laxed => 1, junk_out => \@junk)

--- a/t/50-stuckserver.t
+++ b/t/50-stuckserver.t
@@ -1,0 +1,77 @@
+BEGIN {
+    unless ($ENV{RELEASE_TESTING} || $ENV{THREAD_TESTS}) {
+        require Test::More;
+        Test::More::plan(skip_all=>'these online tests require env variable ONLINE_TESTS be set to run');
+    }
+}
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use LWPx::ParanoidAgent;
+use IO::Socket;
+use Data::Dumper;
+
+use constant TIMEOUT    => 3;
+use constant WAIT       => 4;
+
+my ($server, $host, $port) = make_stuck_http_server();
+
+my $start = time;
+my $ua = LWPx::ParanoidAgent->new(timeout => TIMEOUT, whitelisted_hosts => [$host]);
+
+print $ua->get("http://$host:$port/")->status_line(), "\n";
+my $elapsed = time - $start;
+
+ok(($elapsed) <= TIMEOUT(), 'testing timeout...');
+warn "TOTAL ELAPSED: ", $elapsed, "\n";
+
+$server->kill(15);
+
+sub make_stuck_http_server {
+    use threads;
+
+    my $serv = IO::Socket::INET->new(Listen => 3)
+        or die $@;
+
+    my $thread = threads->create(sub {
+        $SIG{TERM} = sub { threads->exit() };
+
+        while (1) {
+            my $client = $serv->accept()
+                or next;
+
+            my $buf;
+            while (1) {
+                $client->sysread($buf, 1024, length $buf)
+                    or last;
+                if (rindex($buf, "\015\012\015\012") != -1) {
+                    last;
+                }
+            }
+
+            $client->syswrite(
+                join(
+                    "\015\012",
+                    "HTTP/1.1 200 OK",
+                    "Connection: close",
+                    "Content-Type: text/html",
+                    "\015\012"
+                )
+            );
+
+            for (1 .. WAIT()) {
+                $client->syswrite(rand);
+                select undef, undef, undef, 1;
+            }
+
+            $client->close();
+        }
+
+    });
+    $thread->detach();
+
+    return ($thread, $serv->sockhost eq "0.0.0.0" ? "127.0.0.1" : $serv->sockhost, $serv->sockport);
+}


### PR DESCRIPTION
If remote host accepted connection but don't send any headers in return, connection will stuck.

We have to check that any header is sent by remote server before start read it in Net::HTTP (sysread)
